### PR TITLE
Cabal Manifest exposed incorrect module name.

### DIFF
--- a/tomato-rubato.cabal
+++ b/tomato-rubato.cabal
@@ -38,7 +38,7 @@ Library
     exposed-modules:    Demonstrate,
                         Sound.Tomato,
                         Sound.Tomato.MIDI, 
-                        Sound.Tomato.MIX,
+                        Sound.Tomato.Mix,
                         Sound.Tomato.Synthesis,
                         Sound.Tomato.Theory,
                         Sound.Tomato.Types


### PR DESCRIPTION
This fixes one warning during compilation but spawns dozens more, not really sure why?

This could be a horrible pull request.
