### PR TITLE
Fixes #2: Properly frees the audio device and context without crashing

### DIFF
--- a/tomato-rubato-openal/src/Sound/Tomato/Speakers.hs
+++ b/tomato-rubato-openal/src/Sound/Tomato/Speakers.hs
@@ -189,14 +189,11 @@ deInitOpenAL (device,context,pSource,pBuffers) = do
     buffer pSource $= Nothing
     deleteObjectNames [pSource]
     deleteObjectNames pBuffers
-    when (False) $ do
-        -- Not executing the code below fixes a crash on linux.
-        -- It's unproblematic on OS X, too, so why bother.
-        currentContext $= Nothing
-        destroyContext context
-        b <- closeDevice device
-        when (not b) $ fail "closing OpenAL device"
     printErrors
+    currentContext $= Nothing
+    destroyContext context
+    b <- closeDevice device
+    when (not b) $ fail "closing OpenAL device"
 
 -- | Print all OpenAL errors if applicable
 printErrors :: IO ()

--- a/tomato-rubato-openal/src/Sound/Tomato/Speakers.hs
+++ b/tomato-rubato-openal/src/Sound/Tomato/Speakers.hs
@@ -189,6 +189,8 @@ deInitOpenAL (device,context,pSource,pBuffers) = do
     buffer pSource $= Nothing
     deleteObjectNames [pSource]
     deleteObjectNames pBuffers
+    -- printErrors causes a segfault on Linux if it is called after 
+    -- currentContext has been released, so call it here first.
     printErrors
     currentContext $= Nothing
     destroyContext context


### PR DESCRIPTION
This code was previously changed to not execute to avoid the crash reported in #2. But that left a lingering problem: orphaned contexts built up and were never released until the whole program executed. After creating 32 contexts, OpenAL would crash with an out of memory error (on Ubuntu 12.04, libopenal 1.13 with default settings). So if you tried to play 33 sounds in sequence, it would crash on the last one since the contexts weren't being freed.

This commit re-activates the code to free the device and contexts. It solves the Linux crash by moving the call to printErrors to the line before currentContext is set to Nothing. The OpenAL spec doesn't say that alErrors is tied to a particular context, but that is perhaps how it's been implemented in Linux--I'm not totally sure. But putting the printErrors call first provides the best of both worlds: it prevents the GHC crash reported in #2 and it also eliminates the orphaned devices and contexts that build up with each call to withSpeakers.